### PR TITLE
update action to include retry logic when pulling and retagging

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -131,6 +131,7 @@ runs:
       id: promote
       uses: nick-fields/retry@v3
       with:
+        shell: bash
         timeout_seconds: ${{ inputs.promote-retry-timeout-seconds }}
         max_attempts: ${{ inputs.promote-retry-max-attempts }}
         retry_on: timeout


### PR DESCRIPTION
This pull request introduces configurable retry logic to the "Promote" step in the GitHub Action workflow by leveraging the `nick-fields/retry` action. The main changes add new input parameters for retry behavior and update the workflow to use these parameters for more robust promotion handling.

**Enhancements to promotion step reliability:**

* Added two new inputs to `action.yml`—`promote-retry-max-attempts` and `promote-retry-timeout-seconds`—allowing users to configure the maximum number of retry attempts and the timeout duration for the promote step.
* Refactored the "Promote" step to use the `nick-fields/retry@v3` action, enabling automatic retries on timeout using the new input parameters, instead of running the command directly in a shell step.