### PR TITLE
Retry logic

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -131,6 +131,7 @@ runs:
       id: promote
       uses: nick-fields/retry@v3
       with:
+        shell: bash
         timeout_seconds: ${{ inputs.promote-retry-timeout-seconds }}
         max_attempts: ${{ inputs.promote-retry-max-attempts }}
         retry_on: timeout


### PR DESCRIPTION
This pull request adds configurable retry logic to the "Promote" step in the GitHub Action workflow by integrating the `nick-fields/retry` action. Two new input parameters are introduced to control the maximum number of retry attempts and the timeout for each attempt, making the promotion process more robust against transient failures.

**Enhancements to promotion step reliability:**

* Added `promote-retry-max-attempts` and `promote-retry-timeout-seconds` inputs to `action.yml` to allow configuration of retry behavior for the promote step.
* Updated the "Promote" step to use the `nick-fields/retry@v3` action, enabling automatic retries on timeout with configurable attempts and timeout values.