### PR TITLE
`feature` Retry Logic improvements.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -134,7 +134,7 @@ runs:
         shell: bash
         timeout_seconds: ${{ inputs.promote-retry-timeout-seconds }}
         max_attempts: ${{ inputs.promote-retry-max-attempts }}
-        retry_on: timeout
+        retry_on: any
         command: |
           docker pull ${{ steps.from.outputs.tags }}
           

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ inputs:
   promote-retry-timeout-seconds:
     description: 'Promote retry timeout seconds'
     required: false
-    default: '15'
+    default: '3000'
   promote-retry-wait-seconds:
     description: 'Promote retry wait seconds'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,10 @@ inputs:
     description: 'Promote retry timeout seconds'
     required: false
     default: '15'
+  promote-retry-wait-seconds:
+    description: 'Promote retry wait seconds'
+    required: false
+    default: '30'
 
 outputs:
   image:
@@ -133,6 +137,7 @@ runs:
       with:
         shell: bash
         timeout_seconds: ${{ inputs.promote-retry-timeout-seconds }}
+        retry_wait_seconds: ${{ inputs.promote-retry-wait-seconds }}
         max_attempts: ${{ inputs.promote-retry-max-attempts }}
         retry_on: any
         command: |


### PR DESCRIPTION
This pull request updates the configuration for the promotion retry mechanism in the GitHub Action defined in `action.yml`. The main focus is on making the retry logic more robust and configurable.

**Enhancements to retry configuration:**

* Increased the default value of `promote-retry-timeout-seconds` from `15` to `3000` to allow more time for retry attempts.
* Introduced a new input parameter `promote-retry-wait-seconds` with a default value of `30`, allowing configuration of the wait time between retries.
* Updated the `runs` section to use the new `promote-retry-wait-seconds` input for `retry_wait_seconds`.
* Changed the `retry_on` condition from `timeout` to `any`, so the action will retry on any failure, not just timeouts.