### PR TITLE
chore: upgrade actions to Node 24 runtime (SHA-pinned)

### DIFF
--- a/.github/workflows/test-auto-from.yml
+++ b/.github/workflows/test-auto-from.yml
@@ -32,7 +32,7 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Build
         id: build
@@ -64,17 +64,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'success'
           actual: "${{ needs.test.outputs.result }}"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: registry.hub.docker.com/${{ github.event.repository.owner.login }}/${{ github.event.repository.name }}
           actual: "${{ needs.test.outputs.image }}"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
           actual: "${{ needs.test.outputs.tag }}"

--- a/.github/workflows/test-auto-to-no-metadata.yml
+++ b/.github/workflows/test-auto-to-no-metadata.yml
@@ -32,7 +32,7 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Build
         id: build
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'failure'
           actual: "${{ needs.test.outputs.result }}"

--- a/.github/workflows/test-auto-to.yml
+++ b/.github/workflows/test-auto-to.yml
@@ -32,7 +32,7 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Build
         id: build
@@ -64,12 +64,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'success'
           actual: "${{ needs.test.outputs.result }}"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: registry.hub.docker.com/${{ github.event.repository.owner.login }}/${{ github.event.repository.name }}
           actual: "${{ needs.test.outputs.image }}"

--- a/.github/workflows/test-negative.yml
+++ b/.github/workflows/test-negative.yml
@@ -32,7 +32,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./
         id: current
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'failure'
           actual: ${{ needs.test.outputs.result }}

--- a/.github/workflows/test-positive.yml
+++ b/.github/workflows/test-positive.yml
@@ -32,7 +32,7 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Build
         id: build
@@ -65,17 +65,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'success'
           actual: "${{ needs.test.outputs.result }}"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: registry.hub.docker.com/${{ github.event.repository.owner.login }}/${{ github.event.repository.name }}
           actual: "${{ needs.test.outputs.image }}"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
           actual: "${{ needs.test.outputs.tag }}"

--- a/.github/workflows/test-to-no-metadata.yml
+++ b/.github/workflows/test-to-no-metadata.yml
@@ -32,7 +32,7 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Build
         id: build
@@ -66,17 +66,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'success'
           actual: "${{ needs.test.outputs.result }}"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: registry.hub.docker.com/${{ github.event.repository.owner.login }}/${{ github.event.repository.name }}
           actual: "${{ needs.test.outputs.image }}"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
           actual: "${{ needs.test.outputs.tag }}"

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
         expected: true
         actual: ${{ ( inputs.use_metadata == 'true' ) || ( inputs.to != '' ) }}
 
-    - uses: cloudposse/github-action-yaml-config-query@v1
+    - uses: cloudposse/github-action-yaml-config-query@8178e0c0d186f53de40f6bcf8e039f1e6a9aefc5 # v1.0.1
       id: context
       with:
         query: ."${{ inputs.image_name == '' }}"
@@ -83,7 +83,7 @@ runs:
         username: ${{ inputs.login }}
         password: ${{ inputs.password }}
 
-    - uses: cloudposse/github-action-yaml-config-query@v1
+    - uses: cloudposse/github-action-yaml-config-query@8178e0c0d186f53de40f6bcf8e039f1e6a9aefc5 # v1.0.1
       id: from_tags_config
       with:
         query: ."${{ inputs.from == '' }}"
@@ -101,7 +101,7 @@ runs:
         tags: ${{ steps.from_tags_config.outputs.tags }}
         flavor: latest=false
 
-    - uses: cloudposse/github-action-yaml-config-query@v1
+    - uses: cloudposse/github-action-yaml-config-query@8178e0c0d186f53de40f6bcf8e039f1e6a9aefc5 # v1.0.1
       id: to_tags_config
       with:
         query: ."${{ inputs.use_metadata == 'true' }}"
@@ -150,7 +150,7 @@ runs:
             docker push ${value}
           done
 
-    - uses: cloudposse/github-action-yaml-config-query@v1
+    - uses: cloudposse/github-action-yaml-config-query@8178e0c0d186f53de40f6bcf8e039f1e6a9aefc5 # v1.0.1
       id: result
       with:
         query: ."${{ inputs.to == '' }}"


### PR DESCRIPTION
## what

* Bump GitHub Actions references in the workflows (and `action.yml`) to versions running on the
  Node 24 runtime, SHA-pinned with precise version comments:
  * `actions/checkout@v6` → `@3d3c42e5...` `# v7.0.1`
  * `nick-fields/assert-action@v2` → `@0efd6166...` `# v4.0.1`
  * `cloudposse/github-action-yaml-config-query@v1` → `@8178e0c0...` `# v1.0.1`

## why

* GitHub is deprecating the Node 20 runtime; affected workflows emit a deprecation warning and
  are already being force-migrated to Node 24
* SHA pinning with a verified tag comment makes the upgrade deliberate and supply-chain-safe,
  matching the org's direction in cloudposse/.github#261
* Every pinned SHA was verified against its upstream tag

## references

* https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Supersedes #46
Supersedes #45
Supersedes #44
